### PR TITLE
Added Close reference issue steps in PR automation

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -467,7 +467,9 @@ jobs:
 
           var closingIssues = resp.node.closingIssuesReferences.nodes;
           if( closingIssues.length <= 0 ) {
-            core.setOutput('COMMENT', "This pull request does not reference any closing issues.</br>Link reference closing issues to proceed further with this PR.");
+            if( "${{ github.event.action }}" != "closed" ){
+              core.setOutput('COMMENT', "This pull request does not reference any closing issues.</br>Link reference closing issues to proceed further with this PR.");
+            }
             console.log("pull request: " + resp.node.number +" does not reference any closing issues.")
             return false
           }

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -34,7 +34,6 @@ jobs:
           else if( "${{ github.event_name }}" == "pull_request" ) {
             console.log('PullReuqest number:' + '${{ github.event.number }}')
           }
-          console.log(`${{ toJSON(github) }}`)
 
     - name: Check run
       id: check-run

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -651,7 +651,7 @@ jobs:
         else
           for i in $numbers; 
           do 
-            gh issue comment $i --body "Pull Request #${{github.event.number}} closed without merging."  --repo ${{ github.repository }};
+            gh issue comment $i --body "Linked Pull Request: #${{github.event.number}} closed without merging.<br>Have look into it."  --repo ${{ github.repository }};
           done
         fi
     

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -490,7 +490,7 @@ jobs:
         github-token: ${{ secrets.ACCESS_TOKEN }}
         script: |
           const closingIssues = ${{ steps.check-associated-issues.outputs.CLOSING_ISSUES }}
-          var closedRefIssues = closedRefIssues.filter((issue) => issue.state != "OPEN")
+          var closedRefIssues = closingIssues.filter((issue) => issue.state != "OPEN")
           var cmt = ""
           for(let i of closedRefIssues) {
             cmt += "<br>#" + i.number
@@ -508,7 +508,7 @@ jobs:
 
     - name: Find reference issues target Status
       id: find-ref-issues-target-status
-      if: steps.check-associated-issues.outputs.result != 'false'
+      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action != 'closed'
       uses: actions/github-script@v7
       with:
         script: |
@@ -519,7 +519,7 @@ jobs:
           if( ${{ github.event.pull_request.draft }} || "${{ github.event.action }}" == "converted_to_draft") {
             targetOptionVal = "🏗 In progress"
           }
-          else if( ( "${{ github.event.action }}" == "ready_for_review" || reviewers.length > 0 || reviewerTeams.length > 0 ) && "${{ github.event.action }}" != "closed" ) {
+          else if( "${{ github.event.action }}" == "ready_for_review" || reviewers.length > 0 || reviewerTeams.length > 0 ) {
             targetOptionVal = "👀 In review"
           }
           else {
@@ -633,18 +633,28 @@ jobs:
         script:
           console.log("TODO:- Write a step to assign PR")
 
-    - name: Close reference issues
-      id: close-ref-issues
-      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action == 'closed'
+    - name: Handle closed pull request
+      id: handle-closed-pr
+      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action == 'closed' && github.event.pull_request.merged
       env:
         GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       shell: bash
       run : |
-        for i in ${{ steps.get-open-ref-items.outputs.openRefIssueNos }} ;
-        do
-          echo $i
-        done
-
+        input="${{ steps.get-open-ref-items.outputs.openRefIssueNos }}";
+        numbers=$(echo "$input" | sed 's/[][]//g' | sed 's/,/ /g');
+        if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; 
+        then
+          for i in $numbers; 
+          do 
+            gh issue close $i --comment "Closed by #${{github.event.number}}";
+          done
+        else
+          for i in $numbers; 
+          do 
+            gh issue comment $i --body "Pull Request #${{github.event.number}} closed without merging.";
+          done
+        fi
+    
     - name: Job result
       id: job-result
       uses: actions/github-script@v7

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -635,7 +635,7 @@ jobs:
 
     - name: Handle closed pull request
       id: handle-closed-pr
-      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action == 'closed' && github.event.pull_request.merged
+      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action == 'closed'
       env:
         GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       shell: bash

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -646,12 +646,12 @@ jobs:
         then
           for i in $numbers; 
           do 
-            gh issue close $i --comment "Closed by #${{github.event.number}}";
+            gh issue close $i --comment "Closed by #${{github.event.number}}" --repo ${{ github.repository }};
           done
         else
           for i in $numbers; 
           do 
-            gh issue comment $i --body "Pull Request #${{github.event.number}} closed without merging.";
+            gh issue comment $i --body "Pull Request #${{github.event.number}} closed without merging."  --repo ${{ github.repository }};
           done
         fi
     

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, unlabeled, assigned, unassigned]
 
   pull_request:
-    types: [reopened, ready_for_review, converted_to_draft]
+    types: [reopened, ready_for_review, converted_to_draft, closed]
 
 jobs:
   check-valid-run:
@@ -418,7 +418,7 @@ jobs:
   
   pr-automation:
     needs: get-details
-    if: needs.get-details.outputs.result != 'false' && ( github.event_name == 'pull_request' || github.event_name == 'pull_request_review' ) && github.event.action != 'opened'
+    if: needs.get-details.outputs.result != 'false' && github.event_name == 'pull_request' 
     runs-on: ubuntu-latest
 
     outputs:
@@ -495,11 +495,11 @@ jobs:
             cmt += "<br>#" + i.number
           }
           if( closedRefIssues.length == closingIssues.length ) {
-            core.setOutput('COMMENT', "Refence issue of this pull request are not in `OPEN` state:" + cmt + "<br>Is this pull request is still valid?")
+            core.setOutput('COMMENT', "Reference issue of this pull request are not in `OPEN` state:" + cmt + "<br>Is this pull request is still valid?")
             return false
           }
           else if( closedRefIssues.length > 0) {
-            core.setOutput('COMMENT', "Some of refence issue of this pull request are not in `OPEN` state:" + cmt + "<br>Is this pull request is still valid?")
+            core.setOutput('COMMENT', "Some of reference issue of this pull request are not in `OPEN` state:" + cmt + "<br>Is this pull request is still valid?")
             return true;
           }
           core.setOutput('COMMENT', "")
@@ -517,8 +517,8 @@ jobs:
           var targetOptionVal = ""
           if( ${{ github.event.pull_request.draft }} || "${{ github.event.action }}" == "converted_to_draft") {
             targetOptionVal = "🏗 In progress"
-          } 
-          else if("${{ github.event.action }}" == "ready_for_review" || reviewers.length > 0 || reviewerTeams.length > 0 ) {
+          }
+          else if( ( "${{ github.event.action }}" == "ready_for_review" || reviewers.length > 0 || reviewerTeams.length > 0 ) && "${{ github.event.action }}" != "closed" ) {
             targetOptionVal = "👀 In review"
           }
           else {
@@ -533,7 +533,7 @@ jobs:
           core.setOutput("FIELD_ID", fieldNode[0].id)
           core.setOutput("UPDATE_STATUS", "true")
 
-          console.log("Target Status value: " + targetOptionVal + " for OPEN refence issue closing by Pull Request: " + ${{ github.event.number }})
+          console.log("Target Status value: " + targetOptionVal + " for OPEN reference issue closing by Pull Request: " + ${{ github.event.number }})
 
     - name: Get open reference items
       id: get-open-ref-items
@@ -604,7 +604,7 @@ jobs:
             }
           }
           
-          if( isFoundAll == true) {
+          if( isFoundAll == true && itemNodes.length != 0) {
             console.log("All issue found in ${{ vars.MAIN_PRJ }} project.")
           }
           else if ( itemNodes.length != 0) {
@@ -621,6 +621,7 @@ jobs:
           }
           core.setOutput('ITEMS', JSON.stringify(itemNodes))
           core.setOutput('COMMENT', "");
+          core.setOutput('openRefIssueNos', JSON.stringify(openRefIssueNos));
           return true
 
     - name: Check and assign PR
@@ -630,6 +631,18 @@ jobs:
       with:
         script:
           console.log("TODO:- Write a step to assign PR")
+
+    - name: Close reference issues
+      id: close-ref-issues
+      if: steps.check-associated-issues.outputs.result != 'false' && github.event.action == 'closed'
+      env:
+        GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      shell: bash
+      run : |
+        for i in ${{ steps.get-open-ref-items.outputs.openRefIssueNos }} ;
+        do
+          echo $i
+        done
 
     - name: Job result
       id: job-result

--- a/docs/design/workflows/project.yml.md
+++ b/docs/design/workflows/project.yml.md
@@ -11,22 +11,22 @@ title: Github Workflow Current
 ---
   flowchart LR
     subgraph check-valid-run
-      st1[actor-info] --> st2[check-run] --> |OPTION, LABELS, COMMENT, NUM, type|st3[job-result]
+      s10[actor-info] --> st11[check-run] --> |OPTION, LABELS, COMMENT, NUM, type|s12[job-result]
     end
     subgraph get-details
-      s4[get-required-ids] --> |PRJ_ID, ids|s5[fetch-project-details] --> |PRJ|s6[job-result]
+      s20[get-required-ids] --> |PRJ_ID, ids|s21[fetch-project-details] --> |PRJ|s22[job-result]
     end
     subgraph issue-automation
-      s7[find-item] --> |ITEM|s8[find-target-status] --> |OPTION, LABELS, OPTION_NODE, FIELD_ID, UPDATE_STATUS|s9[job-result]
+      s30[find-item] --> |ITEM|s31[find-target-status] --> |OPTION, LABELS, OPTION_NODE, FIELD_ID, UPDATE_STATUS|s32[job-result]
     end
     subgraph pr-automation
-      s10[check-associated-issues] --> |COMMENT, CLOSING_ISSUES, PR_ASSIGNEES|s11[reopened] --> |COMMENT|s12[find-ref-issues-target-status] --> |OPTION_NODE, FIELD_ID, UPDATE_STATUS|s13[get-open-ref-items] --> |COMMENT, ITEMS|s14[check-and-assign-pr] --> s15[job-result]
+      s40[check-associated-issues] --> |COMMENT, CLOSING_ISSUES, PR_ASSIGNEES|s41[reopened] --> |COMMENT|s42[find-ref-issues-target-status] --> |OPTION_NODE, FIELD_ID, UPDATE_STATUS|s43[get-open-ref-items] --> |COMMENT, ITEMS, openRefIssueNos|s44[check-and-assign-pr] --> s45[handle-closed-pr] --> s46[job-result]
     end
     subgraph update-status-sprint
-      s16[collect-inputs] --> |OPTION_NODE, FIELD_ID, UPDATE_STATUS, ITEMS, PRJ, ids|s17[update-status] --> s18[update-sprint] --> s19[job-result]
+      s50[collect-inputs] --> |OPTION_NODE, FIELD_ID, UPDATE_STATUS, ITEMS, PRJ, ids|s51[update-status] --> s52[update-sprint] --> s53[job-result]
     end
     subgraph add-remove-label-comment
-      s20[find-labels-options] --> |LABELS, OPTION, COMMENTS|s21[remove-label] --> s22[issue-comment]
+      s60[find-labels-options] --> |LABELS, OPTION, COMMENTS|s61[remove-label] --> s62[issue-comment]
     end
     
 


### PR DESCRIPTION
## Closes issue references automation when PR closed

## Description
- Added additional steps in `Pull Request Automation` job to handle `pull_request: closed` event.
- New steps will close, closes issue references from pull request whenever pull request merged and comment on issues when pull request closed without merging.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Project Configuration
- [x] Repository Configuration
- [ ] Documentation update - Code guide/ docs (_like, javadoc or api_)
- [ ] Other (please describe):

## Screenshots / GIFs / Media (if applicable)
- NA

## How Has This Been Tested?/ Test Plan
- Making `205-t-pr-merged-automation`  branch as default branch as automation must on default branch to get it executed.

## Checklist:
- [x] My code follows the project’s [coding guidelines](./../../docs/guidelines/coding-guides/). 
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code where necessary.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added tests that verify the functionality of the code (if applicable).
- [x] All new and existing tests pass.

## How to use/ enable
- Once changes merged to default branch it will be enabled automatically.

## Additional Notes
- NA

## Closing issues
closes #205 